### PR TITLE
Fixed params for sampling mechanism used

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -271,16 +271,18 @@ defmodule SpandexDatadog.ApiServer do
           "_dd.p.dm" =>
             case sampling[:sampling_mechanism_used] do
               nil -> nil
-              mechanism -> to_string(mechanism)
+              mechanism -> "-#{to_string(mechanism)}"
             end,
           env: span.env,
           version: span.service_version
         }
         |> add_analytics_sample_rate(span)
         |> add_tags(span),
-      metrics: %{
-        "_sampling_priority_v1" => sampling[:priority]
-      } |> Map.merge(sampling_rate_used_params(sampling))
+      metrics:
+        %{
+          "_sampling_priority_v1" => sampling[:priority]
+        }
+        |> Map.merge(sampling_rate_used_params(sampling))
     }
   end
 

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -279,7 +279,7 @@ defmodule SpandexDatadog.ApiServer do
         |> add_analytics_sample_rate(span)
         |> add_tags(span),
       metrics: %{
-        _sampling_priority_v1: sampling[:priority]
+        "_sampling_priority_v1" => sampling[:priority]
       } |> Map.merge(sampling_rate_used_params(sampling))
     }
   end

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -96,7 +96,7 @@ defmodule SpandexDatadog.ApiServerTest do
       sampling: %{
         priority: DatadogConstants.sampling_priority()[:USER_KEEP],
         sampling_rate_used: 0.5,
-        sampling_mechanism_used: DatadogConstants.sampling_mechanism_used()[:AGENT]
+        sampling_mechanism_used: DatadogConstants.sampling_mechanism_used()[:RULE]
       }
     }
 
@@ -192,7 +192,7 @@ defmodule SpandexDatadog.ApiServerTest do
           "duration" => 100_000,
           "error" => 0,
           "meta" => %{
-            "_dd.p.dm" => "1",
+            "_dd.p.dm" => "-3",
             "bar" => "321",
             "baz" => "{1, 2}",
             "buz" => "blitz",
@@ -203,7 +203,7 @@ defmodule SpandexDatadog.ApiServerTest do
             "zyx" => "[xyz: {1, 2}]"
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "foo",
@@ -217,11 +217,11 @@ defmodule SpandexDatadog.ApiServerTest do
           "duration" => 100_000_000,
           "error" => 0,
           "meta" => %{
-            "_dd.p.dm" => "1",
+            "_dd.p.dm" => "-3",
             "env" => "local"
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "bar",
@@ -235,12 +235,12 @@ defmodule SpandexDatadog.ApiServerTest do
           "duration" => 100_000_000,
           "error" => 0,
           "meta" => %{
-            "_dd.p.dm" => "1",
+            "_dd.p.dm" => "-3",
             "env" => "local",
             "_dd1.sr.eausr" => 1
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "bar",
@@ -301,10 +301,10 @@ defmodule SpandexDatadog.ApiServerTest do
             "is_foo" => "true",
             "version" => "v1",
             "zyx" => "[xyz: {1, 2}]",
-            "_dd.p.dm" => "1"
+            "_dd.p.dm" => "-3"
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "foo",
@@ -319,10 +319,10 @@ defmodule SpandexDatadog.ApiServerTest do
           "error" => 0,
           "meta" => %{
             "env" => "local",
-            "_dd.p.dm" => "1"
+            "_dd.p.dm" => "-3"
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "bar",
@@ -337,11 +337,11 @@ defmodule SpandexDatadog.ApiServerTest do
           "error" => 0,
           "meta" => %{
             "env" => "local",
-            "_dd.p.dm" => "1",
+            "_dd.p.dm" => "-3",
             "_dd1.sr.eausr" => 1
           },
           "metrics" => %{
-            "_dd.agent_psr" => 0.5,
+            "_dd.rule_psr" => 0.5,
             "_sampling_priority_v1" => 2
           },
           "name" => "bar",


### PR DESCRIPTION
Fixed passing `"_dd.rule_psr"` or `"_dd.agent_psr"` based on `sampling_mechanism_used`. 
Fixed building mechanism used param (Python lib for reference [here](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/sampling.py#L102-L103)).