### PR TITLE
Using Logger.warning instead of deprecated Logger.warn

### DIFF
--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -206,7 +206,7 @@ defmodule SpandexDatadog.ApiServer do
         Map.put(agent_state, :sampling_rates, sampling_rates["rate_by_service"])
       end)
     else
-      _ -> Logger.warn(fn -> "Failed to send traces and update the sampling rates: #{inspect(response)}" end)
+      _ -> Logger.warning(fn -> "Failed to send traces and update the sampling rates: #{inspect(response)}" end)
     end
 
     if verbose? do


### PR DESCRIPTION
Using `Logger.warning` instead of deprecated `Logger.warn`.