### PR TITLE
More logs controlled with `verbose?` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [1.6.2](https://github.com/surgeventures/spandex_datadog/compare/v1.6.1...v1.6.2) (2024-06-02)
+## [1.6.3](https://github.com/surgeventures/spandex_datadog/compare/v1.6.2...v1.6.3) (2024-02-14)
+
+## Bug Fixes
+* More logs controlled by verbose? flag by @Artur-Sulej in https://github.com/surgeventures/spandex_datadog/pull/11
+
+## [1.6.2](https://github.com/surgeventures/spandex_datadog/compare/v1.6.1...v1.6.2) (2024-02-06)
 
 ## Bug Fixes
 * Handling errors when saving agent sampling rates to avoid crashing by @JerzyDziala, @Artur-Sulej in https://github.com/surgeventures/spandex_datadog/pull/10

--- a/lib/spandex_datadog/agent_http_client_impl.ex
+++ b/lib/spandex_datadog/agent_http_client_impl.ex
@@ -4,7 +4,8 @@ defmodule SpandexDatadog.AgentHttpClient.Impl do
       body: body,
       headers: headers,
       retry: :transient,
-      retry_delay: &retry_delay/1
+      retry_delay: &retry_delay/1,
+      retry_log_level: false
     )
   end
 

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -208,10 +208,15 @@ defmodule SpandexDatadog.ApiServer do
           end)
 
         resp ->
-          Logger.error(fn -> "non-200 response when sending traces: #{inspect(resp)}" end)
+          if verbose? do
+            Logger.error(fn -> "non-200 response when sending traces: #{inspect(resp)}" end)
+          end
       end
     rescue
-      e -> Logger.error(fn -> "Failed to update the sampling rates: #{inspect(e)}" end)
+      e ->
+        if verbose? do
+          Logger.error(fn -> "Failed to update the sampling rates: #{inspect(e)}" end)
+        end
     end
 
     if verbose? do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule SpandexDatadog.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex_datadog"
-  @version "1.6.2"
+  @version "1.6.3"
 
   def project do
     [

--- a/test/api_server_test.exs
+++ b/test/api_server_test.exs
@@ -357,7 +357,7 @@ defmodule SpandexDatadog.ApiServerTest do
         {:ok, %Req.Response{status: 200, body: "i am not what you expected"}}
       end)
 
-      ApiServer.start_link(batch_size: 1, asynchronous_send?: false)
+      ApiServer.start_link(batch_size: 1, asynchronous_send?: false, verbose?: true)
 
       log =
         capture_log(fn ->


### PR DESCRIPTION
More logs controlled with `verbose? `flag. 