### PR TITLE
Lower timeout and disable retries for trace submission

### DIFF
--- a/lib/spandex_datadog/agent_http_client_impl.ex
+++ b/lib/spandex_datadog/agent_http_client_impl.ex
@@ -3,14 +3,12 @@ defmodule SpandexDatadog.AgentHttpClient.Impl do
     Req.put("http://#{host}:#{port}/v0.4/traces",
       body: body,
       headers: headers,
-      retry: :transient,
-      retry_delay: &retry_delay/1,
-      retry_log_level: false
+      retry: false,
+      connect_options: [
+        timeout: 200
+      ],
+      pool_timeout: 200,
+      receive_timeout: 200
     )
-  end
-
-  defp retry_delay(attempt) do
-    # 3 retries with 10% jitter, example delays: 484ms, 945ms, 1908ms
-    trunc(Integer.pow(2, attempt) * 500 * (1 - 0.1 * :rand.uniform()))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule SpandexDatadog.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex_datadog"
-  @version "1.6.4"
+  @version "1.6.5"
 
   def project do
     [


### PR DESCRIPTION
I believe recurring issues with apps starting when the DD agent goes down is due to memory filling up with trace data.

This PR:
* Disables retries for trace submission. The DD agent should generally be on the same machine as the app, I don't believe there is any value in retrying submission of traces.
* Significantly lowers the timeouts for opening connections, waiting for the pool and receiving a response.

If submitting traces fails, the code already handles this gracefully by logging an error and proceeding. This is the behavior we want.