### PR TITLE
SRE-5283 Extract W3C headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [1.6.5](https://github.com/surgeventures/spandex_datadog/compate/v1.6.4...v1.6.5) (2024-07-09)
+## [1.6.6](https://github.com/surgeventures/spandex_datadog/compare/v1.6.5...v1.6.6) (2024-11-15)
+
+## Features
+
+* Added extraction of trace context from W3C headers (traceparent, tracestate), making the library
+  compatible with OpenTelemetry while maintaining OpenTracing support @Artur-Sulej
+  in https://github.com/surgeventures/spandex_datadog/pull/15
+
+## [1.6.5](https://github.com/surgeventures/spandex_datadog/compare/v1.6.4...v1.6.5) (2024-07-09)
 
 * Disable retries, lower timeouts on trace submission request
 

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -14,7 +14,9 @@ defmodule SpandexDatadog.ApiServer do
   alias SpandexDatadog.AgentHttpClient
 
   defmodule State do
-    @moduledoc false
+    @moduledoc """
+    State struct for the ApiServer.
+    """
 
     @type t :: %State{}
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule SpandexDatadog.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex_datadog"
-  @version "1.6.5"
+  @version "1.6.6"
 
   def project do
     [


### PR DESCRIPTION
This PR adds support for extracting W3C (Open Telemetry) headers, when building `SpanContext`.