### PR TITLE
SRE-5320 Remove redundant log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.6.7](https://github.com/surgeventures/spandex_datadog/compare/v1.6.6...v1.6.7) (2024-12-06)
+
+## Features
+
+* Removed redundant error log when there's no priority param in tracestate. Error is only logged
+  when parsing priority param fails @Artur-Sulej
+* Improved regex for splitting tracestate @Artur-Sulej
+  in https://github.com/surgeventures/spandex_datadog/pull/16
+
 ## [1.6.6](https://github.com/surgeventures/spandex_datadog/compare/v1.6.5...v1.6.6) (2024-11-15)
 
 ## Features

--- a/lib/spandex_datadog/adapter.ex
+++ b/lib/spandex_datadog/adapter.ex
@@ -90,7 +90,7 @@ defmodule SpandexDatadog.Adapter do
 
   defp w3c_priority(tracestate) do
     tracestate
-    |> String.split(",")
+    |> String.split(~r/[ \t]*+,[ \t]*+/)
     |> Enum.find_value(fn vendor_state ->
       case vendor_state do
         "dd=" <> value -> value

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule SpandexDatadog.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex_datadog"
-  @version "1.6.6"
+  @version "1.6.7"
 
   def project do
     [

--- a/test/adapter_test.exs
+++ b/test/adapter_test.exs
@@ -131,6 +131,22 @@ defmodule SpandexDatadog.Test.AdapterTest do
       assert encode_w3c_id(span_context.parent_id) == "3702f1bcf6862126"
     end
 
+    test "priority defaults to 1 when no priority param in tracestate" do
+      conn =
+        :get
+        |> Plug.Test.conn("/")
+        |> Plug.Conn.put_req_header("traceparent", "00-0000000000000000160bc62487e24d01-3702f1bcf6862126-01")
+        |> Plug.Conn.put_req_header("tracestate", "dd=t.dm:-0;p:121bcd413432")
+
+      assert {:ok, %SpanContext{priority: 1}} = Adapter.distributed_context(conn, [])
+      assert {:ok, %SpanContext{} = span_context} = Adapter.distributed_context(conn, [])
+      assert span_context.trace_id == 1_588_581_153_779_109_121
+      assert span_context.parent_id == 3_963_996_415_931_588_902
+      assert span_context.priority == 1
+      assert encode_w3c_id(span_context.trace_id) == "160bc62487e24d01"
+      assert encode_w3c_id(span_context.parent_id) == "3702f1bcf6862126"
+    end
+
     test "returns an error when it cannot parse traceparent" do
       conn =
         :get


### PR DESCRIPTION
* Remove redundant error log when there's no priority param in `tracestate`. 
* Error is only logged when parsing priority param fails. 
* Improved regex for splitting tracestate (borrowed from the [official Ruby lib](https://github.com/DataDog/dd-trace-rb/blob/28675b6daa898731bc1c9824421b11a539fbde12/lib/datadog/tracing/distributed/trace_context.rb#L394)).
* Test for present tracestate without priority param. 