### PR TITLE
Fallback to inode when cannot obtain container_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.0](https://github.com/surgeventures/spandex_datadog/compare/v1.6.7...v1.7.0) (2025-09-23)
+
+## Features
+
+* Fallback to cgroup inode when cannot obtain container_id from cgroup, as container_id might not
+  be present when using cgroup v2.
+
 ## [1.6.7](https://github.com/surgeventures/spandex_datadog/compare/v1.6.6...v1.6.7) (2024-12-06)
 
 ## Features

--- a/lib/spandex_datadog/api_server.ex
+++ b/lib/spandex_datadog/api_server.ex
@@ -31,6 +31,7 @@ defmodule SpandexDatadog.ApiServer do
       :sync_threshold,
       :agent_pid,
       :container_id,
+      :cgroup_inode,
       :trap_exits?
     ]
   end
@@ -102,7 +103,8 @@ defmodule SpandexDatadog.ApiServer do
       sync_threshold: opts[:sync_threshold],
       asynchronous_send?: opts[:asynchronous_send?],
       agent_pid: agent_pid,
-      container_id: get_container_id()
+      container_id: get_container_id(),
+      cgroup_inode: get_cgroup_inode()
     }
 
     {:ok, state}
@@ -112,11 +114,23 @@ defmodule SpandexDatadog.ApiServer do
   @cgroup_ctnr "[0-9a-f]{64}"
   @cgroup_task "[0-9a-f]{32}-\\d+"
   @cgroup_regex Regex.compile!(".*(#{@cgroup_uuid}|#{@cgroup_ctnr}|#{@cgroup_task})(?:\\.scope)?$", "m")
+  @cgroup_path_regexp Regex.compile!("^\\d+:[^:]*:(.+)$", "m")
 
   defp get_container_id() do
     with {:ok, file_binary} <- File.read("/proc/self/cgroup"),
          [_, container_id] <- Regex.run(@cgroup_regex, file_binary) do
       container_id
+    else
+      _ -> nil
+    end
+  end
+
+  defp get_cgroup_inode() do
+    with {:ok, file_binary} <- File.read("/proc/self/cgroup"),
+         [_, relative_fs_cgroup_path] <- Regex.run(@cgroup_path_regexp, file_binary),
+         absolute_fs_cgroup_path <- "/sys/fs/cgroup/#{String.trim(relative_fs_cgroup_path, "/")}",
+         {:ok, %File.Stat{inode: inode}} <- File.stat(absolute_fs_cgroup_path) do
+      inode
     else
       _ -> nil
     end
@@ -190,9 +204,24 @@ defmodule SpandexDatadog.ApiServer do
     :ok
   end
 
-  def send_and_log(traces, %{container_id: container_id, verbose?: verbose?} = state) do
+  def send_and_log(traces, %{container_id: container_id, cgroup_inode: cgroup_inode, verbose?: verbose?} = state) do
     headers = @headers ++ [{"X-Datadog-Trace-Count", length(traces)}]
-    headers = headers ++ List.wrap(if container_id, do: {"Datadog-Container-ID", container_id})
+
+    headers =
+      headers ++
+        cond do
+          container_id ->
+            [
+              {"Datadog-Container-ID", container_id},
+              {"Datadog-Entity-ID", "ci-#{container_id}"}
+            ]
+
+          cgroup_inode ->
+            [{"Datadog-Entity-ID", "in-#{cgroup_inode}"}]
+
+          true ->
+            []
+        end
 
     response =
       traces

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule SpandexDatadog.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex_datadog"
-  @version "1.6.7"
+  @version "1.7.0"
 
   def project do
     [


### PR DESCRIPTION
When using cgroups v2 obtaining container_id from within container seems to not always be possible.

Datadog is aware of this and they've implemented workaround in most of their official tracing libraries:
- [dd-trace-js example](https://github.com/DataDog/dd-trace-js/pull/5508)
- [dd-trace-py example](https://github.com/DataDog/dd-trace-py/blob/c72189816067e03c68c9451dc75ca3a9dc1b08cf/ddtrace/internal/runtime/container.py#L163-L175)

So I basically implemented the same thing in this lib. Code is not the prettiest, but from my limited testing it seems to work.